### PR TITLE
Add IRMF support (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ local
 
 # GPU shaders
 *.glsl
+*.irmf
 # These are library shaders that are used by gsdf. This is where we define reusable shader functions.
 !glbuild/glsllib/*.glsl
 # 3D triangle files.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ All images and shapes in readme were generated using this library.
 
 - **NEW!**: Reusable GLSL code between shaders. See [`glbuild/glsllib`](glbuild/glsllib)
 
+- **NEW!**: [Infinite Resolution Materials Format (IRMF)](https://irmf.io) support.
+
 - Extremely coherent API design.
 
 - UI for visualizing parts, rendered directly from shaders. See [UI example](./examples/ui-mandala) by running `go run ./examples/ui-mandala`
@@ -58,9 +60,10 @@ All images and shapes in readme were generated using this library.
 # Examples
 Find examples under [examples](./examples/) directory. Run on GPU with: `-gpu` flag.
 
-Most 3D examples output two files:
+Most 3D examples output two or three files:
 - `example-name.glsl`: Visualization shader that can be copy pasted into [shadertoy](https://www.shadertoy.com/new) to visualize the part, or rendered within your editor with an extension such as the [Shader Toy Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=stevensona.shader-toy).
 - `example-name.stl`: Triangle model file used in 3D printing software such as [Cura](https://ultimaker.com/software/ultimaker-cura/). Can be visualized online in sites such as [View STL](https://www.viewstl.com/).
+- `example-name.irmf`: (When `-irmf` flag is set) Infinite Resolution Materials Format file. Lossless representation of the part for use in IRMF-compatible 3D printers and editors.
 
 
 Output and timings for
@@ -85,7 +88,7 @@ go run ./examples/npt-flange -resdiv 400 -gpu  1,01s user 1,10s system 95% cpu 2
 
 #### CPU rendering in 9 seconds. 0.4M triangles
 ```sh
-time go run ./examples/npt-flange -resdiv 400 
+time go run ./examples/npt-flange -resdiv 400
 using CPU
 instantiating evaluation SDF took 14.173µs
 wrote nptflange.glsl in 73.155µs
@@ -117,7 +120,7 @@ go run ./examples/fibonacci-showerhead -resdiv 350 -gpu  0,87s user 0,69s system
 
 #### CPU rendering in 36 seconds. 0.3M triangles
 ```sh
-time go run ./examples/fibonacci-showerhead -resdiv 350 
+time go run ./examples/fibonacci-showerhead -resdiv 350
 using CPU
 instantiating evaluation SDF took 27.757µs
 wrote showerhead.glsl in 507.155µs

--- a/examples/bolt/main.go
+++ b/examples/bolt/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"os"
@@ -73,19 +74,20 @@ func run() error {
 	}
 	defer fpvis.Close()
 
-	var fpirmf *os.File
+	var irmfOutput io.Writer
 	if writeIRMF {
-		fpirmf, err = os.Create(irmf)
+		fpirmf, err := os.Create(irmf)
 		if err != nil {
 			return err
 		}
 		defer fpirmf.Close()
+		irmfOutput = fpirmf
 	}
 
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:    fpstl,
 		VisualOutput: fpvis,
-		IRMFOutput:   fpirmf,
+		IRMFOutput:   irmfOutput,
 		Resolution:   float32(resolution),
 		UseGPU:       useGPU,
 	})

--- a/examples/bolt/main.go
+++ b/examples/bolt/main.go
@@ -17,6 +17,7 @@ import (
 
 const visualization = "bolt.glsl"
 const stl = "bolt.stl"
+const irmf = "bolt.irmf"
 
 func init() {
 	runtime.LockOSThread() // For when using GPU this is required.
@@ -44,8 +45,10 @@ func run() error {
 		useGPU     bool
 		resolution float64
 		flagResDiv uint
+		writeIRMF  bool
 	)
 	flag.BoolVar(&useGPU, "gpu", false, "enable GPU usage")
+	flag.BoolVar(&writeIRMF, "irmf", false, "write IRMF file")
 	flag.Float64Var(&resolution, "res", 0, "Set resolution in shape units. Useful for setting the minimum level of detail to a fixed amount for final result. If not set resdiv used [mm/in]")
 	flag.UintVar(&flagResDiv, "resdiv", 200, "Set resolution in bounding box diagonal divisions. Useful for prototyping when constant speed of rendering is desired.")
 	flag.Parse()
@@ -70,9 +73,19 @@ func run() error {
 	}
 	defer fpvis.Close()
 
+	var fpirmf *os.File
+	if writeIRMF {
+		fpirmf, err = os.Create(irmf)
+		if err != nil {
+			return err
+		}
+		defer fpirmf.Close()
+	}
+
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:    fpstl,
 		VisualOutput: fpvis,
+		IRMFOutput:   fpirmf,
 		Resolution:   float32(resolution),
 		UseGPU:       useGPU,
 	})

--- a/examples/fibonacci-showerhead/main.go
+++ b/examples/fibonacci-showerhead/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"runtime"
 
@@ -120,19 +121,20 @@ func run() error {
 	}
 	defer fpvis.Close()
 
-	var fpirmf *os.File
+	var irmfOutput io.Writer
 	if writeIRMF {
-		fpirmf, err = os.Create(irmf)
+		fpirmf, err := os.Create(irmf)
 		if err != nil {
 			return err
 		}
 		defer fpirmf.Close()
+		irmfOutput = fpirmf
 	}
 
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:     fpstl,
 		VisualOutput:  fpvis,
-		IRMFOutput:    fpirmf,
+		IRMFOutput:    irmfOutput,
 		Resolution:    float32(resolution),
 		UseGPU:        useGPU,
 		EnableCaching: !useGPU, // Has many unions, part can likely benefit from caching when using CPU.

--- a/examples/fibonacci-showerhead/main.go
+++ b/examples/fibonacci-showerhead/main.go
@@ -20,6 +20,7 @@ import (
 const (
 	stl           = "showerhead.stl"
 	visualization = "showerhead.glsl"
+	irmf          = "showerhead.irmf"
 )
 
 func init() {
@@ -92,8 +93,10 @@ func run() error {
 		useGPU     bool
 		resolution float64
 		flagResDiv uint
+		writeIRMF  bool
 	)
 	flag.BoolVar(&useGPU, "gpu", false, "enable GPU usage")
+	flag.BoolVar(&writeIRMF, "irmf", false, "write IRMF file")
 	flag.Float64Var(&resolution, "res", 0, "Set resolution in shape units. Useful for setting the minimum level of detail to a fixed amount for final result. If not set resdiv used [mm/in]")
 	flag.UintVar(&flagResDiv, "resdiv", 200, "Set resolution in bounding box diagonal divisions. Useful for prototyping when constant speed of rendering is desired.")
 	flag.Parse()
@@ -117,9 +120,19 @@ func run() error {
 	}
 	defer fpvis.Close()
 
+	var fpirmf *os.File
+	if writeIRMF {
+		fpirmf, err = os.Create(irmf)
+		if err != nil {
+			return err
+		}
+		defer fpirmf.Close()
+	}
+
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:     fpstl,
 		VisualOutput:  fpvis,
+		IRMFOutput:    fpirmf,
 		Resolution:    float32(resolution),
 		UseGPU:        useGPU,
 		EnableCaching: !useGPU, // Has many unions, part can likely benefit from caching when using CPU.

--- a/examples/gasket/main.go
+++ b/examples/gasket/main.go
@@ -20,6 +20,7 @@ const (
 	stl             = "gasket.stl"
 	visualization   = "gasket.glsl"
 	visualization2D = "gasket2D.png"
+	irmf            = "gasket.irmf"
 )
 
 func init() {
@@ -88,8 +89,10 @@ func run() error {
 		useGPU     bool
 		resolution float64
 		flagResDiv uint
+		writeIRMF  bool
 	)
 	flag.BoolVar(&useGPU, "gpu", false, "enable GPU usage")
+	flag.BoolVar(&writeIRMF, "irmf", false, "write IRMF file")
 	flag.Float64Var(&resolution, "res", 0, "Set resolution in shape units. Useful for setting the minimum level of detail to a fixed amount for final result. If not set resdiv used [mm/in]")
 	flag.UintVar(&flagResDiv, "resdiv", 350, "Set resolution in bounding box diagonal divisions. Useful for prototyping when constant speed of rendering is desired.")
 	flag.Parse()
@@ -113,9 +116,19 @@ func run() error {
 	}
 	defer fpvis.Close()
 
+	var fpirmf *os.File
+	if writeIRMF {
+		fpirmf, err = os.Create(irmf)
+		if err != nil {
+			return err
+		}
+		defer fpirmf.Close()
+	}
+
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:    fpstl,
 		VisualOutput: fpvis,
+		IRMFOutput:   fpirmf,
 		Resolution:   float32(resolution),
 		UseGPU:       useGPU,
 	})

--- a/examples/gasket/main.go
+++ b/examples/gasket/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"runtime"
 	"time"
@@ -116,19 +117,20 @@ func run() error {
 	}
 	defer fpvis.Close()
 
-	var fpirmf *os.File
+	var irmfOutput io.Writer
 	if writeIRMF {
-		fpirmf, err = os.Create(irmf)
+		fpirmf, err := os.Create(irmf)
 		if err != nil {
 			return err
 		}
 		defer fpirmf.Close()
+		irmfOutput = fpirmf
 	}
 
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:    fpstl,
 		VisualOutput: fpvis,
-		IRMFOutput:   fpirmf,
+		IRMFOutput:   irmfOutput,
 		Resolution:   float32(resolution),
 		UseGPU:       useGPU,
 	})

--- a/examples/metric-spacers/metric-spacers.go
+++ b/examples/metric-spacers/metric-spacers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"runtime"
@@ -94,13 +95,15 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		var fpirmf *os.File
+		defer fpstl.Close()
+		var irmfOutput io.Writer
 		if writeIRMF {
-			fpirmf, err = os.Create(strSpacers[i] + ".irmf")
+			fpirmf, err := os.Create(strSpacers[i] + ".irmf")
 			if err != nil {
-				fpstl.Close()
 				return err
 			}
+			defer fpirmf.Close()
+			irmfOutput = fpirmf
 		}
 
 		if resolution == 0 {
@@ -108,14 +111,10 @@ func run() error {
 		}
 		err = gsdfaux.RenderShader3D(sdf, gsdfaux.RenderConfig{
 			STLOutput:  fpstl,
-			IRMFOutput: fpirmf,
+			IRMFOutput: irmfOutput,
 			Resolution: float32(resolution),
 			UseGPU:     useGPU,
 		})
-		fpstl.Close()
-		if fpirmf != nil {
-			fpirmf.Close()
-		}
 	}
 	return nil
 }

--- a/examples/metric-spacers/metric-spacers.go
+++ b/examples/metric-spacers/metric-spacers.go
@@ -42,8 +42,10 @@ func run() error {
 		flagResDiv    uint
 		flagSpacers   string
 		scaleDiameter float64
+		writeIRMF     bool
 	)
 	flag.BoolVar(&useGPU, "gpu", false, "enable GPU usage")
+	flag.BoolVar(&writeIRMF, "irmf", false, "write IRMF file")
 	flag.Float64Var(&resolution, "res", 0, "Set resolution in shape units. Useful for setting the minimum level of detail to a fixed amount for final result. If not set resdiv used [mm/in]")
 	flag.UintVar(&flagResDiv, "resdiv", 200, "Set resolution in bounding box diagonal divisions. Useful for prototyping when constant speed of rendering is desired.")
 	flag.StringVar(&flagSpacers, "spacers", "M3x5", "Spacers to generate with format arg[,arg] where arg has format M<d>x<L> d is diameter of hole and L is length.")
@@ -92,15 +94,28 @@ func run() error {
 		if err != nil {
 			return err
 		}
+		var fpirmf *os.File
+		if writeIRMF {
+			fpirmf, err = os.Create(strSpacers[i] + ".irmf")
+			if err != nil {
+				fpstl.Close()
+				return err
+			}
+		}
+
 		if resolution == 0 {
 			resolution = float64(sdf.Bounds().Diagonal()) / float64(flagResDiv)
 		}
 		err = gsdfaux.RenderShader3D(sdf, gsdfaux.RenderConfig{
 			STLOutput:  fpstl,
+			IRMFOutput: fpirmf,
 			Resolution: float32(resolution),
 			UseGPU:     useGPU,
 		})
 		fpstl.Close()
+		if fpirmf != nil {
+			fpirmf.Close()
+		}
 	}
 	return nil
 }

--- a/examples/npt-flange/flange.go
+++ b/examples/npt-flange/flange.go
@@ -15,6 +15,7 @@ import (
 
 const visualization = "nptflange.glsl"
 const stl = "nptflange.stl"
+const irmf = "nptflange.irmf"
 
 func init() {
 	runtime.LockOSThread() // For when using GPU this is required.
@@ -63,8 +64,10 @@ func run() error {
 		useGPU     bool
 		resolution float64
 		flagResDiv uint
+		writeIRMF  bool
 	)
 	flag.BoolVar(&useGPU, "gpu", false, "enable GPU usage")
+	flag.BoolVar(&writeIRMF, "irmf", false, "write IRMF file")
 	flag.Float64Var(&resolution, "res", 0, "Set resolution in shape units. Useful for setting the minimum level of detail to a fixed amount for final result. If not set resdiv used [mm/in]")
 	flag.UintVar(&flagResDiv, "resdiv", 200, "Set resolution in bounding box diagonal divisions. Useful for prototyping when constant speed of rendering is desired.")
 	flag.Parse()
@@ -88,9 +91,19 @@ func run() error {
 	}
 	defer fpvis.Close()
 
+	var fpirmf *os.File
+	if writeIRMF {
+		fpirmf, err = os.Create(irmf)
+		if err != nil {
+			return err
+		}
+		defer fpirmf.Close()
+	}
+
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:    fpstl,
 		VisualOutput: fpvis,
+		IRMFOutput:   fpirmf,
 		Resolution:   float32(resolution),
 		UseGPU:       useGPU,
 	})

--- a/examples/npt-flange/flange.go
+++ b/examples/npt-flange/flange.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"runtime"
@@ -91,19 +92,20 @@ func run() error {
 	}
 	defer fpvis.Close()
 
-	var fpirmf *os.File
+	var irmfOutput io.Writer
 	if writeIRMF {
-		fpirmf, err = os.Create(irmf)
+		fpirmf, err := os.Create(irmf)
 		if err != nil {
 			return err
 		}
 		defer fpirmf.Close()
+		irmfOutput = fpirmf
 	}
 
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:    fpstl,
 		VisualOutput: fpvis,
-		IRMFOutput:   fpirmf,
+		IRMFOutput:   irmfOutput,
 		Resolution:   float32(resolution),
 		UseGPU:       useGPU,
 	})

--- a/examples/plantpot/main.go
+++ b/examples/plantpot/main.go
@@ -22,6 +22,7 @@ const (
 	stl             = exampleName + ".stl"
 	visualization   = exampleName + ".glsl"
 	visualization2D = exampleName + ".png"
+	irmf            = exampleName + ".irmf"
 	potBaseRadius   = 40.
 )
 
@@ -69,8 +70,10 @@ func run() error {
 		useGPU     bool
 		resolution float64
 		flagResDiv uint
+		writeIRMF  bool
 	)
 	flag.BoolVar(&useGPU, "gpu", false, "enable GPU usage")
+	flag.BoolVar(&writeIRMF, "irmf", false, "write IRMF file")
 	flag.Float64Var(&resolution, "res", 0, "Set resolution in shape units. Useful for setting the minimum level of detail to a fixed amount for final result. If not set resdiv used [mm/in]")
 	flag.UintVar(&flagResDiv, "resdiv", 350, "Set resolution in bounding box diagonal divisions. Useful for prototyping when constant speed of rendering is desired.")
 	flag.Parse()
@@ -93,9 +96,19 @@ func run() error {
 	}
 	defer fpvis.Close()
 
+	var fpirmf *os.File
+	if writeIRMF {
+		fpirmf, err = os.Create(irmf)
+		if err != nil {
+			return err
+		}
+		defer fpirmf.Close()
+	}
+
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:    fpstl,
 		VisualOutput: fpvis,
+		IRMFOutput:   fpirmf,
 		Resolution:   float32(resolution),
 		UseGPU:       useGPU,
 	})

--- a/examples/plantpot/main.go
+++ b/examples/plantpot/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 
 	"runtime"
@@ -96,19 +97,20 @@ func run() error {
 	}
 	defer fpvis.Close()
 
-	var fpirmf *os.File
+	var irmfOutput io.Writer
 	if writeIRMF {
-		fpirmf, err = os.Create(irmf)
+		fpirmf, err := os.Create(irmf)
 		if err != nil {
 			return err
 		}
 		defer fpirmf.Close()
+		irmfOutput = fpirmf
 	}
 
 	err = gsdfaux.RenderShader3D(object, gsdfaux.RenderConfig{
 		STLOutput:    fpstl,
 		VisualOutput: fpvis,
-		IRMFOutput:   fpirmf,
+		IRMFOutput:   irmfOutput,
 		Resolution:   float32(resolution),
 		UseGPU:       useGPU,
 	})

--- a/glbuild/irmf.go
+++ b/glbuild/irmf.go
@@ -1,0 +1,59 @@
+package glbuild
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// IRMFHeader represents the JSON header for an Infinite Resolution Materials Format (IRMF) file.
+type IRMFHeader struct {
+	Author      string         `json:"author,omitempty"`
+	Copyright   string         `json:"copyright,omitempty"`
+	Date        string         `json:"date,omitempty"`
+	Encoding    string         `json:"encoding,omitempty"`
+	GLSLVersion string         `json:"glslVersion,omitempty"`
+	IRMF        string         `json:"irmf"`
+	Materials   []string       `json:"materials"`
+	Max         [3]float32     `json:"max"`
+	Min         [3]float32     `json:"min"`
+	Notes       string         `json:"notes,omitempty"`
+	Options     map[string]any `json:"options,omitempty"`
+	Title       string         `json:"title,omitempty"`
+	Units       string         `json:"units"`
+	Version     string         `json:"version,omitempty"`
+}
+
+// WriteIRMF creates the IRMF shader program for calculating SDF and writes it to the writer.
+func (p *Programmer) WriteIRMF(w io.Writer, obj Shader3D, header IRMFHeader) (n int, objs []ShaderObject, err error) {
+	// 1. Serialize and write the JSON header wrapped in /*...*/
+	headerData, err := json.MarshalIndent(header, "", "  ")
+	if err != nil {
+		return 0, nil, err
+	}
+
+	ngot, err := fmt.Fprintf(w, "/*%s*/\n", headerData)
+	n += ngot
+	if err != nil {
+		return n, nil, err
+	}
+
+	// 2. Write the SDF function declarations.
+	baseName, ngot, objs, err := p.WriteSDFDecl(w, obj)
+	n += ngot
+	if err != nil {
+		return n, objs, err
+	}
+
+	// 3. Append the IRMF-specific main function. (We assume 1-4 materials for now.)
+	ngot, err = fmt.Fprintf(w, `
+void mainModel4(out vec4 materials, in vec3 xyz) {
+	float d = %v(xyz);
+	materials = vec4(d <= 0.0 ? 1.0 : 0.0, 0.0, 0.0, 0.0);
+}
+`,
+		baseName)
+	n += ngot
+
+	return n, objs, err
+}

--- a/glbuild/irmf.go
+++ b/glbuild/irmf.go
@@ -9,11 +9,12 @@ import (
 // IRMFHeader represents the JSON header for an Infinite Resolution Materials Format (IRMF) file.
 type IRMFHeader struct {
 	Author      string         `json:"author,omitempty"`
-	Copyright   string         `json:"copyright,omitempty"`
+	License     string         `json:"license,omitempty"`
 	Date        string         `json:"date,omitempty"`
 	Encoding    string         `json:"encoding,omitempty"`
+	IRMFVersion string         `json:"irmf"`
 	GLSLVersion string         `json:"glslVersion,omitempty"`
-	IRMF        string         `json:"irmf"`
+	Language    string         `json:"language"`
 	Materials   []string       `json:"materials"`
 	Max         [3]float32     `json:"max"`
 	Min         [3]float32     `json:"min"`
@@ -29,31 +30,46 @@ func (p *Programmer) WriteIRMF(w io.Writer, obj Shader3D, header IRMFHeader) (n 
 	// 1. Serialize and write the JSON header wrapped in /*...*/
 	headerData, err := json.MarshalIndent(header, "", "  ")
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, fmt.Errorf("marshal error: %w", err)
 	}
 
 	ngot, err := fmt.Fprintf(w, "/*%s*/\n", headerData)
 	n += ngot
 	if err != nil {
-		return n, nil, err
+		return n, nil, fmt.Errorf("fprintf error: %w", err)
 	}
 
 	// 2. Write the SDF function declarations.
 	baseName, ngot, objs, err := p.WriteSDFDecl(w, obj)
 	n += ngot
 	if err != nil {
-		return n, objs, err
+		return n, objs, fmt.Errorf("write SDF decl error: %w", err)
 	}
 
 	// 3. Append the IRMF-specific main function. (We assume 1-4 materials for now.)
-	ngot, err = fmt.Fprintf(w, `
+	switch header.Language {
+	case "glsl":
+		ngot, err = fmt.Fprintf(w, `
 void mainModel4(out vec4 materials, in vec3 xyz) {
-	float d = %v(xyz);
-	materials = vec4(d <= 0.0 ? 1.0 : 0.0, 0.0, 0.0, 0.0);
+  float d = %v(xyz);
+  materials = vec4(d <= 0.0 ? 1.0 : 0.0, 0.0, 0.0, 0.0);
 }
 `,
-		baseName)
-	n += ngot
+			baseName)
+		n += ngot
+	case "wgsl":
+		ngot, err = fmt.Fprintf(w, `
+fn mainModel4(xyz: vec3f) -> vec4f {
+  let d = %v(xyz);
+  let materials = vec4f(d <= 0.0 ? 1.0 : 0.0, 0.0, 0.0, 0.0);
+  return materials;
+}
+`,
+			baseName)
+		n += ngot
+	default:
+		return n, nil, fmt.Errorf("unknown IRMF language: %q", header.Language)
+	}
 
 	return n, objs, err
 }

--- a/glbuild/irmf.go
+++ b/glbuild/irmf.go
@@ -2,12 +2,13 @@ package glbuild
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 )
 
-// IRMFHeader represents the JSON header for an Infinite Resolution Materials Format (IRMF) file.
-type IRMFHeader struct {
+// IRMFHeaderV1 represents the JSON header for an Infinite Resolution Materials Format (IRMF) file.
+type IRMFHeaderV1 struct {
 	Author      string         `json:"author,omitempty"`
 	License     string         `json:"license,omitempty"`
 	Date        string         `json:"date,omitempty"`
@@ -26,9 +27,13 @@ type IRMFHeader struct {
 }
 
 // WriteIRMF creates the IRMF shader program for calculating SDF and writes it to the writer.
-func (p *Programmer) WriteIRMF(w io.Writer, obj Shader3D, header IRMFHeader) (n int, objs []ShaderObject, err error) {
+func (ih IRMFHeaderV1) WriteIRMF(w io.Writer, obj Shader3D, programmer *Programmer) (n int, objs []ShaderObject, err error) {
+	if programmer == nil {
+		return 0, nil, errors.New("programmer is nil")
+	}
+
 	// 1. Serialize and write the JSON header wrapped in /*...*/
-	headerData, err := json.MarshalIndent(header, "", "  ")
+	headerData, err := json.MarshalIndent(ih, "", "  ")
 	if err != nil {
 		return 0, nil, fmt.Errorf("marshal error: %w", err)
 	}
@@ -40,14 +45,14 @@ func (p *Programmer) WriteIRMF(w io.Writer, obj Shader3D, header IRMFHeader) (n 
 	}
 
 	// 2. Write the SDF function declarations.
-	baseName, ngot, objs, err := p.WriteSDFDecl(w, obj)
+	baseName, ngot, objs, err := programmer.WriteSDFDecl(w, obj)
 	n += ngot
 	if err != nil {
 		return n, objs, fmt.Errorf("write SDF decl error: %w", err)
 	}
 
 	// 3. Append the IRMF-specific main function. (We assume 1-4 materials for now.)
-	switch header.Language {
+	switch ih.Language {
 	case "glsl":
 		ngot, err = fmt.Fprintf(w, `
 void mainModel4(out vec4 materials, in vec3 xyz) {
@@ -68,7 +73,7 @@ fn mainModel4(xyz: vec3f) -> vec4f {
 			baseName)
 		n += ngot
 	default:
-		return n, nil, fmt.Errorf("unknown IRMF language: %q", header.Language)
+		return n, nil, fmt.Errorf("unknown IRMF language: %q", ih.Language)
 	}
 
 	return n, objs, err

--- a/gsdfaux/gsdfaux.go
+++ b/gsdfaux/gsdfaux.go
@@ -10,7 +10,6 @@ import (
 	"image/png"
 	"io"
 	"os"
-	"reflect"
 
 	"time"
 
@@ -58,7 +57,7 @@ func RenderShader3D(s glbuild.Shader3D, cfg RenderConfig) (err error) {
 		cfg.builder = &gsdf.Builder{}
 	}
 	bld := cfg.builder
-	if isNil(cfg.STLOutput) && isNil(cfg.VisualOutput) {
+	if cfg.STLOutput == nil && cfg.VisualOutput == nil {
 		return errors.New("RenderShader3D requires output parameter in config")
 	}
 	log := func(elapsed time.Duration, args ...any) {
@@ -151,7 +150,7 @@ func RenderShader3D(s glbuild.Shader3D, cfg RenderConfig) (err error) {
 		return err
 	}
 
-	if !isNil(cfg.VisualOutput) {
+	if cfg.VisualOutput != nil {
 		visualWatch := stopwatch()
 		const sceneSize = 1.4
 		// We include the bounding box in the visualization.
@@ -181,13 +180,13 @@ func RenderShader3D(s glbuild.Shader3D, cfg RenderConfig) (err error) {
 		log(visualWatch(), "wrote", filename)
 	}
 
-	if !isNil(cfg.IRMFOutput) {
+	if cfg.IRMFOutput != nil {
 		if err := renderIRMF(cfg, s, "glsl"); err != nil {
 			return err
 		}
 	}
 
-	if !isNil(cfg.STLOutput) {
+	if cfg.STLOutput != nil {
 		var userData any
 		maybeVP, err := gleval.GetVecPool(sdf)
 		if err == nil {
@@ -301,16 +300,4 @@ func MakeGPUSDF2(s glbuild.Shader2D) (sdf gleval.SDF2, err error) {
 		InvocX:        invoc,
 		ShaderObjects: objects,
 	})
-}
-
-func isNil(i any) bool {
-	if i == nil {
-		return true
-	}
-	v := reflect.ValueOf(i)
-	switch v.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
-		return v.IsNil()
-	}
-	return false
 }

--- a/gsdfaux/gsdfaux.go
+++ b/gsdfaux/gsdfaux.go
@@ -24,6 +24,7 @@ import (
 type RenderConfig struct {
 	STLOutput    io.Writer
 	VisualOutput io.Writer
+	IRMFOutput   io.Writer
 	// Resolution decides the STL output resolution. It correlates with the minimum triangle size.
 	Resolution float32
 	UseGPU     bool
@@ -177,6 +178,12 @@ func RenderShader3D(s glbuild.Shader3D, cfg RenderConfig) (err error) {
 			filename = fp.Name()
 		}
 		log(visualWatch(), "wrote", filename)
+	}
+
+	if cfg.IRMFOutput != nil {
+		if err := renderIRMF(cfg, s); err != nil {
+			return err
+		}
 	}
 
 	if cfg.STLOutput != nil {

--- a/gsdfaux/gsdfaux.go
+++ b/gsdfaux/gsdfaux.go
@@ -10,6 +10,7 @@ import (
 	"image/png"
 	"io"
 	"os"
+	"reflect"
 
 	"time"
 
@@ -57,7 +58,7 @@ func RenderShader3D(s glbuild.Shader3D, cfg RenderConfig) (err error) {
 		cfg.builder = &gsdf.Builder{}
 	}
 	bld := cfg.builder
-	if cfg.STLOutput == nil && cfg.VisualOutput == nil {
+	if isNil(cfg.STLOutput) && isNil(cfg.VisualOutput) {
 		return errors.New("RenderShader3D requires output parameter in config")
 	}
 	log := func(elapsed time.Duration, args ...any) {
@@ -150,7 +151,7 @@ func RenderShader3D(s glbuild.Shader3D, cfg RenderConfig) (err error) {
 		return err
 	}
 
-	if cfg.VisualOutput != nil {
+	if !isNil(cfg.VisualOutput) {
 		visualWatch := stopwatch()
 		const sceneSize = 1.4
 		// We include the bounding box in the visualization.
@@ -180,13 +181,13 @@ func RenderShader3D(s glbuild.Shader3D, cfg RenderConfig) (err error) {
 		log(visualWatch(), "wrote", filename)
 	}
 
-	if cfg.IRMFOutput != nil {
-		if err := renderIRMF(cfg, s); err != nil {
+	if !isNil(cfg.IRMFOutput) {
+		if err := renderIRMF(cfg, s, "glsl"); err != nil {
 			return err
 		}
 	}
 
-	if cfg.STLOutput != nil {
+	if !isNil(cfg.STLOutput) {
 		var userData any
 		maybeVP, err := gleval.GetVecPool(sdf)
 		if err == nil {
@@ -300,4 +301,16 @@ func MakeGPUSDF2(s glbuild.Shader2D) (sdf gleval.SDF2, err error) {
 		InvocX:        invoc,
 		ShaderObjects: objects,
 	})
+}
+
+func isNil(i any) bool {
+	if i == nil {
+		return true
+	}
+	v := reflect.ValueOf(i)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
 }

--- a/gsdfaux/irmf.go
+++ b/gsdfaux/irmf.go
@@ -11,7 +11,7 @@ func renderIRMF(cfg RenderConfig, s glbuild.Shader3D, language string) error {
 	irmfWatch := stopwatch()
 	bb := s.Bounds()
 	min, max := bb.Min, bb.Max
-	header := glbuild.IRMFHeader{
+	header := glbuild.IRMFHeaderV1{
 		IRMFVersion: "1.0",
 		Language:    language,
 		Materials:   []string{"material0"},
@@ -21,7 +21,8 @@ func renderIRMF(cfg RenderConfig, s glbuild.Shader3D, language string) error {
 	}
 
 	var objects []glbuild.ShaderObject
-	_, objects, err := glbuild.NewDefaultProgrammer().WriteIRMF(cfg.IRMFOutput, s, header)
+	programmer := glbuild.NewDefaultProgrammer()
+	_, objects, err := header.WriteIRMF(cfg.IRMFOutput, s, programmer)
 	if err != nil {
 		return fmt.Errorf("writing IRMF: %w", err)
 	}

--- a/gsdfaux/irmf.go
+++ b/gsdfaux/irmf.go
@@ -1,0 +1,40 @@
+package gsdfaux
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/soypat/gsdf/glbuild"
+)
+
+func renderIRMF(cfg RenderConfig, s glbuild.Shader3D) error {
+	irmfWatch := stopwatch()
+	bb := s.Bounds()
+	min, max := bb.Min, bb.Max
+	header := glbuild.IRMFHeader{
+		IRMF:      "1.0",
+		Materials: []string{"material0"},
+		Min:       [3]float32{min.X, min.Y, min.Z},
+		Max:       [3]float32{max.X, max.Y, max.Z},
+		Units:     "mm",
+	}
+
+	var objects []glbuild.ShaderObject
+	_, objects, err := glbuild.NewDefaultProgrammer().WriteIRMF(cfg.IRMFOutput, s, header)
+	if err != nil {
+		return fmt.Errorf("writing IRMF: %w", err)
+	}
+
+	for i := range objects {
+		if objects[i].IsBindable() {
+			return fmt.Errorf("bindable objects unsupported for IRMF shader generation: %v", objects[i])
+		}
+	}
+
+	filename := "model.irmf"
+	if fp, ok := cfg.IRMFOutput.(*os.File); ok {
+		filename = fp.Name()
+	}
+	fmt.Printf("[%v] wrote %v\n", irmfWatch(), filename)
+	return nil
+}

--- a/gsdfaux/irmf.go
+++ b/gsdfaux/irmf.go
@@ -7,16 +7,17 @@ import (
 	"github.com/soypat/gsdf/glbuild"
 )
 
-func renderIRMF(cfg RenderConfig, s glbuild.Shader3D) error {
+func renderIRMF(cfg RenderConfig, s glbuild.Shader3D, language string) error {
 	irmfWatch := stopwatch()
 	bb := s.Bounds()
 	min, max := bb.Min, bb.Max
 	header := glbuild.IRMFHeader{
-		IRMF:      "1.0",
-		Materials: []string{"material0"},
-		Min:       [3]float32{min.X, min.Y, min.Z},
-		Max:       [3]float32{max.X, max.Y, max.Z},
-		Units:     "mm",
+		IRMFVersion: "1.0",
+		Language:    language,
+		Materials:   []string{"material0"},
+		Min:         [3]float32{min.X, min.Y, min.Z},
+		Max:         [3]float32{max.X, max.Y, max.Z},
+		Units:       "mm",
 	}
 
 	var objects []glbuild.ShaderObject


### PR DESCRIPTION
Hi @soypat! I just saw your excellent GopherCon 2025 talk and my jaw dropped when I saw your `gsdf` project.
I've been excited by SDFs for a long time now and Go has been my favorite programming language for a long time, so when I saw that you were modeling geometry in Go and writing out shaders to generate geometry, I was hooked.

This PR adds [IRMF](https://irmf.io) support to `gsdf` because it seems like a really natural fit... I hope you agree.

Here are a few screenshots of examples from `gsdf` viewed in the [IRMF editor](https://gmlewis.github.io/irmf-editor/):

- `bolt.irmf`

<img width="2559" height="1281" alt="bolt irmf" src="https://github.com/user-attachments/assets/fe6b1c83-84a1-4dff-af48-0e24892e5e00" />

- `showerhead.irmf`

<img width="2559" height="1277" alt="showerhead irmf" src="https://github.com/user-attachments/assets/4091f7c6-0276-470b-be21-ccb91db97fff" />

- `plantpot.irmf`

<img width="2559" height="1283" alt="plantpot irmf" src="https://github.com/user-attachments/assets/92f3da51-e299-4c3c-8921-4e50185a74bf" />
